### PR TITLE
Add custom distro support

### DIFF
--- a/cooker/cooker-menu-schema.json
+++ b/cooker/cooker-menu-schema.json
@@ -91,8 +91,45 @@
         "local.conf": {
             "$ref": "#/definitions/local.conf"
         },
+
         "base-distribution": {
-            "$ref": "#/definitions/not-empty-string"
+            "type": "object",
+            "properties": {
+                "distro-name": {
+                    "$ref": "#/definitions/not-empty-string"
+                },
+                "base-directory": {
+                    "$ref": "#/definitions/not-empty-string"
+                },
+                "build-script": {
+                    "$ref": "#/definitions/not-empty-string"
+                },
+                "template-conf": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/not-empty-string"
+                    }
+                },
+                "default-conf-version": {
+                    "$ref": "#/definitions/not-empty-string"
+                },
+                "layer-conf-name": {
+                    "$ref": "#/definitions/not-empty-string"
+                },
+                "layer-conf-version": {
+                    "$ref": "#/definitions/not-empty-string"
+                },
+                "package-classes": {
+                    "$ref": "#/definitions/not-empty-string"
+                },
+                "default-bitbake-major-version": {
+                    "$ref": "#/definitions/not-empty-string"
+                },
+                "bitbake-init-file": {
+                    "$ref": "#/definitions/not-empty-string"
+                }
+            },
+            "additionalProperties": false
         },
 
         "builds": {
@@ -141,25 +178,6 @@
 
         "notes": {
             "$ref": "#/definitions/notes"
-        },
-
-        "override_distro": {
-            "type": "object",
-            "properties": {
-                "base_directory": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "build_script": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "template_conf": {
-                    "type": "string",
-                    "minLength": 1
-                }
-            },
-            "additionalProperties": false
         }
     },
     "required": ["sources", "builds"],

--- a/test/basic/build/test
+++ b/test/basic/build/test
@@ -70,11 +70,14 @@ cooker init -f menu.json
 cooker build
 
 
-# `cooker init` fails when base-distro is unknown
+# `cooker init` fails when a base-distro field is unknown
 cat > menu.json <<-EOF
 	{
 	    "sources": [],
-	    "base-distribution": "wingardium-leviosa",
+	    "base-distribution": {
+	      "unknow-field": "foobar",
+	      "distro-name": "arago"
+	    },
 	    "layers": [],
 	    "builds": {
 	        "build-1" : {
@@ -89,51 +92,18 @@ EOF
 expect_fail cooker init -f menu.json
 
 
-# `cooker build` succeeds with Poky base-distro
-cat > menu.json <<-EOF
-	{
-	    "sources": [],
-	    "base-distribution": "poky",
-	    "layers": [],
-	    "builds": {
-	        "build-1" : {
-	            "target": "core-image-base",
-	            "local.conf": [
-	                "MACHINE = qemu-x86"
-	            ]
-	        }
-	    }
-	}
-EOF
-cooker init -f menu.json
-cooker build
-
-
-# `cooker build` accepts 'Poky' (capitalized)
-cat > menu.json <<-EOF
-	{
-	    "sources": [],
-	    "base-distribution": "Poky",
-	    "layers": [],
-	    "builds": {
-	        "build-1" : {
-	            "target": "core-image-base",
-	            "local.conf": [
-	                "MACHINE = qemu-x86"
-	            ]
-	        }
-	    }
-	}
-EOF
-cooker init -f menu.json
-cooker build
-
-
 # `cooker build` fails with Arago base-distro and no env-init script
 cat > menu.json <<-EOF
 	{
 	    "sources": [],
-	    "base-distribution": "arago",
+	    "base-distribution": {
+	      "distro-name": "arago",
+	      "base-directory": "openembedded-core",
+	      "template-conf": ["meta/conf"],
+	      "layer-conf-name": "LCONF_VERSION",
+	      "layer-conf-version": "7",
+	      "package-classes": "package_ipk"
+	    },
 	    "layers": [],
 	    "builds": {
 	        "build-1" : {
@@ -157,7 +127,14 @@ touch layers/openembedded-core/oe-init-build-env
 cat > menu.json <<-EOF
 	{
 	    "sources": [],
-	    "base-distribution": "arago",
+	    "base-distribution": {
+	      "distro-name": "arago",
+	      "base-directory": "openembedded-core",
+	      "template-conf": ["meta/conf"],
+	      "layer-conf-name": "LCONF_VERSION",
+	      "layer-conf-version": "7",
+	      "package-classes": "package_ipk"
+	    },
 	    "layers": [],
 	    "builds": {
 	        "build-1" : {
@@ -172,24 +149,6 @@ EOF
 cooker init -f menu.json
 cooker build
 
-# `cooker build` accepts 'Arago' (capitalized)
-cat > menu.json <<-EOF
-	{
-	    "sources": [],
-	    "base-distribution": "Arago",
-	    "layers": [],
-	    "builds": {
-	        "build-1" : {
-	            "target": "core-image-base",
-	            "local.conf": [
-	                "MACHINE = qemu-x86"
-	            ]
-	        }
-	    }
-	}
-EOF
-cooker init -f menu.json
-cooker build
 
 rm -rf layers/openembedded-core
 

--- a/test/basic/dry-run/output.ref
+++ b/test/basic/dry-run/output.ref
@@ -45,7 +45,7 @@ cat > /builds/build-pi2-base/conf/local.conf <<-EOF
 	INHERIT += 'extrausers'
 	EXTRA_USERS_PARAMS_append = 'usermod -P root root;'
 	DISTRO ?= "poky"
-	PACKAGE_CLASSES ?= "package_rpm"
+	PACKAGE_CLASSES ??= "package_rpm"
 	BB_DISKMON_DIRS ??= "\
 		STOPTASKS,\${TMPDIR},1G,100K \
 		STOPTASKS,\${DL_DIR},1G,100K \

--- a/test/basic/dry-run/override-menu.json
+++ b/test/basic/dry-run/override-menu.json
@@ -4,10 +4,10 @@
         "generic/layer1",
         "generic/layer2"
     ],
-    "override_distro": {
-        "base_directory": "poky",
-        "build_script": "oe-init-build-env",
-        "template_conf": "../meta-yocto/meta-poky/conf/templates/default"
+    "base-distribution": {
+        "base-directory": "poky",
+        "build-script": "oe-init-build-env",
+        "template-conf": ["../meta-yocto/meta-poky/conf/templates/default"]
     },
     "builds": {
         "override": {


### PR DESCRIPTION
## Context
The distro values in cooker are used to generate the local.conf files and run the build script. By default Cooker only supported the Poky distro. 

A [issue](https://github.com/cpb-/yocto-cooker/issues/97) was opened to support custom distro. The implemented solution is to add a python file next to the menu file containing the custom distro python class. The goal was to import the distro class and overwrite the built-in Poky class from the 'base-distribution' menu field value. However, this solution is not fully implemented, only the built-in Poky and Arago classes can be selected from 'base-distribution'.

## Feature
This PR adds the custom distro support with a different way. Since custom distro are usually based on Poky distro, a better approach is to only overwrite the desired values directly from the menu file.

The 'base-distribution' replaces the existing 'override-distro' which only supported to overwrite 'base-directory', 'build-script' and 'template-conf' distro values. The new 'base-distribution' can overwrite all distro values. The Poky distro class is considered as the Base distro class and the Arago distro class is removed.

```python
class BaseDistro:

    DISTRO_NAME = "poky"
    BASE_DIRECTORY = "poky"
    BUILD_SCRIPT = "oe-init-build-env"
    TEMPLATE_CONF = ("meta-poky/conf", "meta-poky/conf/templates/default")
    DEFAULT_CONF_VERSION = "1"
    LAYER_CONF_NAME = "POKY_BBLAYERS_CONF_VERSION"
    LAYER_CONF_VERSION = "2"
    PACKAGE_CLASSES = "package_rpm"
    DEFAULT_BITBAKE_MAJOR_VERSION = 2
    BITBAKE_INIT_FILE = "bitbake/lib/bb/__init__.py"
```

Thus, without setting the 'base-distribution' the Poky values are used. For example, to use the Arago distro the 'base-distribution' should be:

```json
"base-distribution": {
  "distro-name": "arago",
  "base-directory": "openembedded-core",
  "template-conf": ["meta/conf"],
  "layer-conf-name": "LCONF_VERSION",
  "layer-conf-version": "7",
  "package-classes": "package_ipk"
},
```


